### PR TITLE
pin nodejs-express stack to 0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ install:
 
 script:
  # Initialize frontend project
+ - appsody repo add nodejs-express-v02 https://github.com/appsody/stacks/releases/download/nodejs-express-v0.2.10/incubator-index.yaml
  - mkdir quote-frontend-project
  - cd quote-frontend-project
- - appsody init nodejs-express
+ - appsody init nodejs-express-v02/nodejs-express
  # Use jq to add dependencies to package.json
  - jq -s ".[0] * .[1]" package.json ../ci/package-add.json >package.json.tmp && mv package.json.tmp package.json
  # Copy files from git into the project

--- a/README.md
+++ b/README.md
@@ -63,14 +63,21 @@ git clone https://github.com/IBM/appsody-sample-quote-app
 
 ### 2. Create the frontend application and run it locally
 
-The frontend application is written in Node.js Express.  First let's initialize an Appsody project that uses the Node.js Express stack.
+The frontend application is written in Node.js Express.  First let's initialize an Appsody project that uses the Node.js Express stack. Appsody stack development uses a release process that defines a repo of available stacks. The code written in this pattern to extend the stack template is based on the v0.2 stack. Begin by configuring an additional Appsody repo with a [release](https://github.com/appsody/stacks/releases/tag/nodejs-express-v0.2.10) that includes this stack:
+
+```bash
+$ appsody repo add nodejs-express-v02 https://github.com/appsody/stacks/releases/download/nodejs-express-v0.2.10/incubator-index.yaml
+```
+
 Create a directory somewhere outside where you cloned this project and run the `appsody init` command shown below.
 
 ```bash
 $ mkdir quote-frontend
 $ cd quote-frontend
-$ appsody init nodejs-express
+$ appsody init nodejs-express-v02/nodejs-express
 ```
+
+> The `nodejs-express-v02` qualifier tells appsody to use the repo that was just added with the Node.js Express v0.2 stack.
 
 After `appsody init` completes, list the content of the directory.  You'll see that Appsody has created a starter application for you.
 


### PR DESCRIPTION
Update to travis and pattern steps to add an Appsody repo compatible with quote-frontend code.

Add short explanatory text about Appsody repos.

Does not also use this repo for the quote-backend application. The default Appsody repo is still used for quote-backend.

fixes #11 